### PR TITLE
Add s6-v3 and cleanup bash

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# This file is globally distributed to all container image projects from
+# https://github.com/linuxserver/docker-jenkins-builder/blob/master/.editorconfig
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+# trim_trailing_whitespace may cause unintended issues and should not be globally set true
+trim_trailing_whitespace = false
+
+[{Dockerfile*,**.yml}]
+indent_style = space
+indent_size = 2
+
+[{**.sh,root/etc/s6-overlay/s6-rc.d/**,root/etc/cont-init.d/**,root/etc/services.d/**}]
+indent_style = space
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,27 +10,27 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
- echo "**** install build packages ****" && \
- apt-get update && \
- apt-get install -y \
-	cabal-install \
-	curl \
-	ghc \
-	git && \
- echo "**** compile shellcheck ****" && \
- git clone https://github.com/koalaman/shellcheck /tmp/shellcheck && \
- cd /tmp/shellcheck && \
- cabal update && \
- cabal install --dependencies-only && \
- cabal build Paths_ShellCheck && \
- ghc \
-	-idist/build/autogen \
-	-isrc \
-	-optl-pthread \
-	-optl-static \
-	--make \
-	shellcheck && \
- strip --strip-all shellcheck
+    echo "**** install build packages ****" && \
+    apt-get update && \
+    apt-get install -y \
+        cabal-install \
+        curl \
+        ghc \
+        git && \
+    echo "**** compile shellcheck ****" && \
+    git clone https://github.com/koalaman/shellcheck /tmp/shellcheck && \
+    cd /tmp/shellcheck && \
+    cabal update && \
+    cabal install --dependencies-only && \
+    cabal build Paths_ShellCheck && \
+    ghc \
+        -idist/build/autogen \
+        -isrc \
+        -optl-pthread \
+        -optl-static \
+        --make \
+        shellcheck && \
+    strip --strip-all shellcheck
 
 ############## runtime stage ##############
 FROM scratch

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -31,9 +31,9 @@ if [[ -d "${WORKSPACE}"/root/etc/services.d ]]; then
     TEST_AREA+=("root/etc/services.d")
 fi
 
-if [[ -d "${WORKSPACE}"/root/docker-mods,root/etc/s6-overlay/s6-rc.d/ ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/docker-mods,root/etc/s6-overlay/s6-rc.d/:/root/docker-mods,root/etc/s6-overlay/s6-rc.d/")
-    TEST_AREA+=("root/docker-mods,root/etc/s6-overlay/s6-rc.d/")
+if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d/ ]]; then
+    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/s6-overlay/s6-rc.d/:/root/etc/s6-overlay/s6-rc.d/")
+    TEST_AREA+=("root/etc/s6-overlay/s6-rc.d/")
 fi
 
 # check test area for executable files

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -31,9 +31,9 @@ if [[ -d "${WORKSPACE}"/root/etc/services.d ]]; then
     TEST_AREA+=("root/etc/services.d")
 fi
 
-if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d/ ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/s6-overlay/s6-rc.d/:/root/etc/s6-overlay/s6-rc.d/")
-    TEST_AREA+=("root/etc/s6-overlay/s6-rc.d/")
+if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d ]]; then
+    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:/root/etc/s6-overlay/s6-rc.d")
+    TEST_AREA+=("root/etc/s6-overlay/s6-rc.d")
 fi
 
 # check test area for executable files

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -12,27 +12,27 @@ MOUNT_OPTIONS=()
 TEST_AREA=()
 
 if [[ -d "${WORKSPACE}"/init ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/init:/init")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/init:/init")
     TEST_AREA+=("init")
 fi
 
 if [[ -d "${WORKSPACE}"/services ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/services:/services")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/services:/services")
     TEST_AREA+=("services")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/cont-init.d ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/cont-init.d:/root/etc/cont-init.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/cont-init.d:/root/etc/cont-init.d")
     TEST_AREA+=("root/etc/cont-init.d")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/services.d ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/services.d:/root/etc/services.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/services.d:/root/etc/services.d")
     TEST_AREA+=("root/etc/services.d")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d ]]; then
-    MOUNT_OPTIONS+=("-v ${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:/root/etc/s6-overlay/s6-rc.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:/root/etc/s6-overlay/s6-rc.d")
     TEST_AREA+=("root/etc/s6-overlay/s6-rc.d")
 fi
 

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -69,6 +69,9 @@ fi
 
 # run shellcheck
 docker pull "${SHELLCKECK_IMAGE}"
+docker run --rm -t \
+    "${SHELLCKECK_IMAGE}" \
+    shellcheck --version
 find "${EXECUTABLE_FILES[@]}" -exec \
     docker run --rm -t \
     "${MOUNT_OPTIONS[@]}" \

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -13,9 +13,7 @@ SHELLCKECK_IMAGE="koalaman/shellcheck:stable"
 TEST_AREA=()
 
 # clear preexising checkstyle files
-if [[ -f "${WORKSPACE}"/shellcheck-result.xml ]]; then
-    rm "${WORKSPACE}"/shellcheck-result.xml
-fi
+echo "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'></checkstyle>" >"${WORKSPACE}"/shellcheck-result.xml
 
 if [[ -d "${WORKSPACE}"/init ]]; then
     MOUNT_OPTIONS+=("-v" "${WORKSPACE}/init:/init")
@@ -79,10 +77,6 @@ find "${ALL_SHELL_FILES[@]}" -exec \
     shellcheck \
     "${SHELLCHECK_OPTIONS[@]}" {} + \
     >"${WORKSPACE}"/shellcheck-result.xml
-
-if [[ ! -f ${WORKSPACE}/shellcheck-result.xml ]]; then
-    echo "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'></checkstyle>" >"${WORKSPACE}"/shellcheck-result.xml
-fi
 
 # exit gracefully
 exit 0

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -76,6 +76,7 @@ find "${EXECUTABLE_FILES[@]}" -exec \
     docker run --rm -t \
     "${MOUNT_OPTIONS[@]}" \
     "${SHELLCKECK_IMAGE}" \
+    shellcheck \
     "${SHELLCHECK_OPTIONS[@]}" {} + \
     >"${WORKSPACE}"/shellcheck-result.xml
 

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -9,9 +9,7 @@ EXECUTABLE_FILES=()
 MOUNT_OPTIONS=()
 NON_EXECUTABLE_FILES=()
 SHELLCHECK_OPTIONS=("--exclude=SC1008" "--format=checkstyle" "--shell=bash")
-SHELLCKECK_IMAGE="ghcr.io/linuxserver/lsiodev-shellcheck"
-# consider using official shellcheck image
-#SHELLCKECK_IMAGE="koalaman/shellcheck:stable"
+SHELLCKECK_IMAGE="koalaman/shellcheck:stable"
 TEST_AREA=()
 
 # clear preexising checkstyle files

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -64,13 +64,22 @@ fi
 
 # run shellcheck
 docker pull ghcr.io/linuxserver/lsiodev-shellcheck
-
 docker run \
     --rm=true -t \
     "${MOUNT_OPTIONS[@]}" \
     ghcr.io/linuxserver/lsiodev-shellcheck \
     find "${EXECUTABLE_FILES[@]}" -exec shellcheck "${SHELLCHECK_OPTIONS[@]}" {} + \
     >"${WORKSPACE}"/shellcheck-result.xml
+
+# consider using official shellcheck image
+# docker pull koalaman/shellcheck:stable
+# find "${EXECUTABLE_FILES[@]}" -exec \
+#     docker run \
+#         --rm -t \
+#         "${MOUNT_OPTIONS[@]}" \
+#         koalaman/shellcheck:stable \
+#         "${SHELLCHECK_OPTIONS[@]}" {} + \
+#         >"${WORKSPACE}"/shellcheck-result.xml
 
 if [[ ! -f ${WORKSPACE}/shellcheck-result.xml ]]; then
     echo "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'></checkstyle>" >"${WORKSPACE}"/shellcheck-result.xml


### PR DESCRIPTION
Better bash logic:

- Initiate empty arrays
- Check if directories exist and add them to the array
- Check if the directories contain executable shell scripts (includes the name of a shell in the first line of the file)
  - This should avoid the s6 v3 files that are not shell scripts
- Include shellcheck version in output (our built image is outdated)

Called from https://github.com/linuxserver/docker-jenkins-builder/blob/55104184f91a6f220ca0c12dab83fead4d1ed1fc/roles/generate-jenkins/templates/Jenkinsfile.j2#L408
Not sure if we have a way to do early testing