### PR TITLE
Fix workdir

### DIFF
--- a/checkrun.sh
+++ b/checkrun.sh
@@ -1,42 +1,41 @@
 #!/bin/bash
 
-# clear preexisting variables not set by job
-unset ALL_SHELL_FILES EXECUTABLE_FILES MOUNT_OPTIONS NON_EXECUTABLE_FILES SHELLCHECK_OPTIONS SHELLCKECK_IMAGE TEST_AREA
-
 # initialize variables
 ALL_SHELL_FILES=()
 EXECUTABLE_FILES=()
 MOUNT_OPTIONS=()
 NON_EXECUTABLE_FILES=()
+SHELLCHECK_ENTRYPOINT="/bin/shellcheck"
+SHELLCHECK_IMAGE="koalaman/shellcheck:stable"
 SHELLCHECK_OPTIONS=("--exclude=SC1008" "--format=checkstyle" "--shell=bash")
-SHELLCKECK_IMAGE="koalaman/shellcheck:stable"
+SHELLCHECK_WORKDIR="/mnt"
 TEST_AREA=()
 
 # clear preexising checkstyle files
 echo "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'></checkstyle>" >"${WORKSPACE}"/shellcheck-result.xml
 
 if [[ -d "${WORKSPACE}"/init ]]; then
-    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/init:/init")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/init:${SHELLCHECK_WORKDIR}/init")
     TEST_AREA+=("init")
 fi
 
 if [[ -d "${WORKSPACE}"/services ]]; then
-    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/services:/services")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/services:${SHELLCHECK_WORKDIR}/services")
     TEST_AREA+=("services")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/cont-init.d ]]; then
-    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/cont-init.d:/root/etc/cont-init.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/cont-init.d:${SHELLCHECK_WORKDIR}/root/etc/cont-init.d")
     TEST_AREA+=("root/etc/cont-init.d")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/services.d ]]; then
-    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/services.d:/root/etc/services.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/services.d:${SHELLCHECK_WORKDIR}/root/etc/services.d")
     TEST_AREA+=("root/etc/services.d")
 fi
 
 if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d ]]; then
-    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:/root/etc/s6-overlay/s6-rc.d")
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:${SHELLCHECK_WORKDIR}/root/etc/s6-overlay/s6-rc.d")
     TEST_AREA+=("root/etc/s6-overlay/s6-rc.d")
 fi
 
@@ -66,15 +65,16 @@ if [[ ${#ALL_SHELL_FILES[@]} -eq 0 ]]; then
 fi
 
 # run shellcheck
-docker pull "${SHELLCKECK_IMAGE}"
+docker pull "${SHELLCHECK_IMAGE}"
 docker run --rm -t \
-    "${SHELLCKECK_IMAGE}" \
+    "${SHELLCHECK_IMAGE}" \
     shellcheck --version
 find "${ALL_SHELL_FILES[@]}" -exec \
     docker run --rm -t \
+    --entrypoint "${SHELLCHECK_ENTRYPOINT}" \
+    --workdir "${SHELLCHECK_WORKDIR}" \
     "${MOUNT_OPTIONS[@]}" \
-    "${SHELLCKECK_IMAGE}" \
-    shellcheck \
+    "${SHELLCHECK_IMAGE}" \
     "${SHELLCHECK_OPTIONS[@]}" {} + \
     >"${WORKSPACE}"/shellcheck-result.xml
 


### PR DESCRIPTION
- `unset` is unnecessary (all variables are initialized)
- Define `SHELLCHECK_ENTRYPOINT`. `koalaman/shellcheck:stable` uses a different endpoint than our image (which we're no longer using). Just in case it changes upstream we can adjust here.
- Fix spelling of `SHELLCHECK_IMAGE`
- Include `SHELLCHECK_WORKDIR` so shellcheck can actually find the scripts. This is the main reason for the PR. Without it, we get results like this https://ci-tests.linuxserver.io/lspipepr/nextcloud/25.0.3-pkg-0f8aa801-pr-282/shellcheck-result.xml where shellcheck is looking for `root/...` but it should have been `/root/...`. I couldn't come up with a clever way to prepend the `/` because of how I'm using `find` so I prepended the mount points for the docker volumes with the `SHELLCHECK_WORKDIR`