### PR TITLE
Exit when no TEST_AREA is found

### DIFF
--- a/checkrun.sh
+++ b/checkrun.sh
@@ -39,6 +39,12 @@ if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d ]]; then
     TEST_AREA+=("root/etc/s6-overlay/s6-rc.d")
 fi
 
+# exit gracefully if no TEST_AREA are found
+if [[ ${#TEST_AREA[@]} -eq 0 ]]; then
+    echo "no common folders found, linting not required"
+    exit 0
+fi
+
 # check test area for executable files
 while IFS= read -r -d '' file; do
     if head -n1 "${file}" | grep -q -E -w "sh|bash|dash|ksh"; then


### PR DESCRIPTION
Prevents find command on L58 from passing the current working directory to the loop

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

